### PR TITLE
DXP-1584: Fix idle config updates

### DIFF
--- a/src/main/java/dev/streamx/sling/connector/impl/StreamxClientConfigImpl.java
+++ b/src/main/java/dev/streamx/sling/connector/impl/StreamxClientConfigImpl.java
@@ -6,10 +6,14 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component(service = StreamxClientConfig.class)
 @Designate(ocd = StreamxClientConfigOcd.class, factory = true)
 public class StreamxClientConfigImpl implements StreamxClientConfig {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamxClientConfigImpl.class);
 
   private String name;
   private String streamxUrl;
@@ -43,5 +47,9 @@ public class StreamxClientConfigImpl implements StreamxClientConfig {
     this.streamxUrl = config.streamxUrl();
     this.authToken = config.authToken();
     this.resourcePathPatterns = Arrays.asList(config.resourcePathPatterns());
+    LOG.trace(
+            "Applied configuration. Name: '{}'. URL: '{}'. Resource path patterns: '{}'.",
+            name, streamxUrl, resourcePathPatterns
+    );
   }
 }

--- a/src/main/java/dev/streamx/sling/connector/impl/StreamxClientFactoryImpl.java
+++ b/src/main/java/dev/streamx/sling/connector/impl/StreamxClientFactoryImpl.java
@@ -43,6 +43,7 @@ public class StreamxClientFactoryImpl implements StreamxClientFactory {
         .setAuthToken(!StringUtils.isBlank(config.getAuthToken()) ? config.getAuthToken() : null)
         .setApacheHttpClient(httpClient)
         .build();
+    LOG.trace("Created StreamX client for: '{}'", config.getStreamxUrl());
     return new StreamxInstanceClient(streamxClient, config);
   }
 

--- a/src/main/java/dev/streamx/sling/connector/impl/StreamxClientStoreImpl.java
+++ b/src/main/java/dev/streamx/sling/connector/impl/StreamxClientStoreImpl.java
@@ -1,41 +1,72 @@
 package dev.streamx.sling.connector.impl;
 
 import dev.streamx.clients.ingestion.exceptions.StreamxClientException;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(service = StreamxClientStore.class)
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component(
+        service = StreamxClientStore.class,
+        immediate = true,
+        reference = @Reference(
+                service = StreamxClientConfig.class,
+                cardinality = ReferenceCardinality.AT_LEAST_ONE,
+                policyOption = ReferencePolicyOption.GREEDY,
+                bind = "bindStreamxClientStore",
+                unbind = "unbindStreamxClientStore",
+                updated = "updateStreamxClientStore",
+                policy = ReferencePolicy.DYNAMIC,
+                name = "streamxClientConfig"
+        )
+)
 public class StreamxClientStoreImpl implements StreamxClientStore {
 
   private static final Logger LOG = LoggerFactory.getLogger(StreamxClientStoreImpl.class);
-  private final Map<String, StreamxInstanceClient> clientsByName = new ConcurrentHashMap<>();
 
-  @Reference
-  private StreamxClientFactory streamxClientFactory;
-
-  @Reference(
-      service = StreamxClientConfig.class,
-      cardinality = ReferenceCardinality.AT_LEAST_ONE,
-      policyOption = ReferencePolicyOption.GREEDY
-  )
-  private List<StreamxClientConfig> configs;
+  private final Map<String, StreamxInstanceClient> clientsByName;
+  private final StreamxClientFactory streamxClientFactory;
 
   @Activate
-  @Modified
-  private void activate() {
-    configs.forEach(config -> clientsByName.computeIfAbsent(config.getName(),
-            key -> initStreamxInstanceClient(config)));
+  public StreamxClientStoreImpl(
+          @Reference(cardinality = ReferenceCardinality.MANDATORY)
+          StreamxClientFactory streamxClientFactory
+  ) {
+    this.clientsByName = new ConcurrentHashMap<>();
+    this.streamxClientFactory = streamxClientFactory;
+  }
+
+  @SuppressWarnings("unused")
+  void bindStreamxClientStore(StreamxClientConfig config) {
+    String configName = config.getName();
+    LOG.debug("Adding StreamX client for: '{}'", configName);
+    initStreamxInstanceClient(config).ifPresentOrElse(
+            client -> clientsByName.put(configName, client),
+            () -> LOG.error("An error occurred during adding of the StreamX client: '{}'", configName)
+    );
+  }
+
+  @SuppressWarnings("unused")
+  void unbindStreamxClientStore(StreamxClientConfig config) {
+    String configName = config.getName();
+    LOG.debug("Removing StreamX client for: '{}'", configName);
+    clientsByName.remove(configName);
+  }
+
+  @SuppressWarnings("unused")
+  void updateStreamxClientStore(StreamxClientConfig config) {
+    String configName = config.getName();
+    LOG.debug("Updating StreamX client for: '{}'", configName);
+    initStreamxInstanceClient(config).ifPresentOrElse(
+            client -> clientsByName.put(configName, client),
+            () -> LOG.error("An error occurred during the update of the StreamX client: '{}'", configName)
+    );
   }
 
   @Override
@@ -51,12 +82,13 @@ public class StreamxClientStoreImpl implements StreamxClientStore {
     return clientsByName.get(name);
   }
 
-  private StreamxInstanceClient initStreamxInstanceClient(StreamxClientConfig config) {
+  private Optional<StreamxInstanceClient> initStreamxInstanceClient(StreamxClientConfig config) {
+    LOG.debug("Initializing StreamX client for: '{}'. URL: '{}'", config.getName(), config.getStreamxUrl());
     try {
-      return streamxClientFactory.createStreamxClient(config);
+      return Optional.of(streamxClientFactory.createStreamxClient(config));
     } catch (StreamxClientException e) {
       LOG.error("An error occurred during the creation of the StreamX client.", e);
-      return null;
+      return Optional.empty();
     }
   }
 }

--- a/src/test/java/dev/streamx/sling/connector/impl/PublicationJobExecutorTest.java
+++ b/src/test/java/dev/streamx/sling/connector/impl/PublicationJobExecutorTest.java
@@ -42,7 +42,7 @@ class PublicationJobExecutorTest {
     slingContext.registerService(StreamxClientFactory.class, new FakeStreamxClientFactory());
 
     slingContext.registerInjectActivateService(new DefaultPublicationRetryPolicy());
-    slingContext.registerInjectActivateService(new StreamxClientStoreImpl());
+    slingContext.registerInjectActivateService(StreamxClientStoreImpl.class);
     slingContext.registerInjectActivateService(new PublicationHandlerRegistry());
     slingContext.registerInjectActivateService(publicationJobExecutor);
   }

--- a/src/test/java/dev/streamx/sling/connector/impl/StreamxPublicationServiceImplTest.java
+++ b/src/test/java/dev/streamx/sling/connector/impl/StreamxPublicationServiceImplTest.java
@@ -1,15 +1,6 @@
 package dev.streamx.sling.connector.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssumptions.given;
-
-import dev.streamx.sling.connector.PublicationHandler;
-import dev.streamx.sling.connector.PublicationRetryPolicy;
-import dev.streamx.sling.connector.RelatedResourcesSelector;
-import dev.streamx.sling.connector.StreamxPublicationException;
-import dev.streamx.sling.connector.StreamxPublicationService;
+import dev.streamx.sling.connector.*;
 import dev.streamx.sling.connector.testing.handlers.AssetPublicationHandler;
 import dev.streamx.sling.connector.testing.handlers.ImpostorPublicationHandler;
 import dev.streamx.sling.connector.testing.handlers.OtherPagePublicationHandler;
@@ -17,13 +8,6 @@ import dev.streamx.sling.connector.testing.handlers.PagePublicationHandler;
 import dev.streamx.sling.connector.testing.selectors.RelatedPagesSelector;
 import dev.streamx.sling.connector.testing.sling.event.jobs.FakeJobManager;
 import dev.streamx.sling.connector.testing.streamx.clients.ingestion.FakeStreamxClient;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -36,6 +20,14 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssumptions.given;
 
 @ExtendWith(SlingContextExtension.class)
 class StreamxPublicationServiceImplTest {
@@ -66,7 +58,6 @@ class StreamxPublicationServiceImplTest {
 
     StreamxPublicationServiceImpl publicationServiceImpl = new StreamxPublicationServiceImpl();
     JobExecutor publicationJobExecutor = new PublicationJobExecutor();
-    StreamxClientStoreImpl streamxClientStore = new StreamxClientStoreImpl();
 
     for (FakeStreamxClientConfig config : fakeStreamxClientConfigs) {
       slingContext.registerService(StreamxClientConfig.class, config);
@@ -83,7 +74,7 @@ class StreamxPublicationServiceImplTest {
     for (RelatedResourcesSelector selector : relatedResourcesSelectors) {
       slingContext.registerService(RelatedResourcesSelector.class, selector);
     }
-    slingContext.registerInjectActivateService(streamxClientStore);
+    slingContext.registerInjectActivateService(StreamxClientStoreImpl.class);
     slingContext.registerInjectActivateService(new PublicationHandlerRegistry());
 
     slingContext.registerInjectActivateService(new RelatedResourcesSelectorRegistry());


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [ ] Non-breaking change
- [X] Bug fix / minor change

## 🛠 Changes being made

`StreamxClientStoreImpl` is implemented incorrectly. `StreamxClientStoreImpl` depends on the instances of `StreamxClientConfig`. However, when OSGi configuration of a `StreamxClientConfig` instance is updated during runtime, those changes aren't reflected in `StreamxClientStoreImpl`, which continues to function with the outdated configuration of `StreamxClientConfig`.

This PR fixes the bug above in such way that all updates of OSGi configuration of `StreamxClientConfig` during runtime are reflected in the `StreamxClientStoreImpl`.
![image](https://github.com/user-attachments/assets/ace5240f-2ab1-42e7-a980-ceaa0f7ca34f)

## ✅ Checklist

- [X] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [X] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
