### PR TITLE
DXP-1668: Rescue secret interpolation

### DIFF
--- a/src/main/java/dev/streamx/sling/connector/impl/OSGiSecret.java
+++ b/src/main/java/dev/streamx/sling/connector/impl/OSGiSecret.java
@@ -1,0 +1,28 @@
+package dev.streamx.sling.connector.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OSGiSecret {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OSGiSecret.class);
+  private final String value;
+
+  OSGiSecret(String value) {
+    // Interpolation fails when `secretsdir` property isn't set,
+    // what is the case by default for local AEMaaCS:
+    // https://github.com/apache/felix-dev/blob/e479f6517c4bcbf5fcdd73c20b8760fe1610ab3a/configadmin-plugins/interpolation/README.md?plain=1#L133
+    boolean interpolationFailed = value.startsWith("$[secret:") && value.endsWith("]");
+    if (interpolationFailed) {
+      LOG.warn("Interpolation failed for secret: {}. Empty value will be used as a fallback", value);
+      this.value = StringUtils.EMPTY;
+    } else {
+      this.value = value;
+    }
+  }
+
+  String get() {
+    return value;
+  }
+}

--- a/src/main/java/dev/streamx/sling/connector/impl/StreamxClientConfigImpl.java
+++ b/src/main/java/dev/streamx/sling/connector/impl/StreamxClientConfigImpl.java
@@ -28,14 +28,14 @@ public class StreamxClientConfigImpl implements StreamxClientConfig {
   private static final Logger LOG = LoggerFactory.getLogger(StreamxClientConfigImpl.class);
   private final AtomicReference<String> name;
   private final AtomicReference<String> streamxUrl;
-  private final AtomicReference<String> authToken;
+  private final AtomicReference<OSGiSecret> authToken;
   private final AtomicReference<List<String>> resourcePathPatterns;
 
   @Activate
   public StreamxClientConfigImpl(StreamxClientConfigOcd config) {
     this.name = new AtomicReference<>(config.name());
     this.streamxUrl = new AtomicReference<>(config.streamxUrl());
-    this.authToken = new AtomicReference<>(config.authToken());
+    this.authToken = new AtomicReference<>(new OSGiSecret(config.authToken()));
     this.resourcePathPatterns = new AtomicReference<>(Arrays.asList(config.resourcePathPatterns()));
     LOG.trace(
         "Applied configuration. Name: '{}'. URL: '{}'. Resource path patterns: '{}'.",
@@ -47,7 +47,7 @@ public class StreamxClientConfigImpl implements StreamxClientConfig {
   private void configure(StreamxClientConfigOcd config) {
     name.set(config.name());
     streamxUrl.set(config.streamxUrl());
-    authToken.set(config.authToken());
+    authToken.set(new OSGiSecret(config.authToken()));
     resourcePathPatterns.set(Arrays.asList(config.resourcePathPatterns()));
     LOG.trace(
         "Applied configuration. Name: '{}'. URL: '{}'. Resource path patterns: '{}'.",
@@ -67,7 +67,7 @@ public class StreamxClientConfigImpl implements StreamxClientConfig {
 
   @Override
   public String getAuthToken() {
-    return authToken.get();
+    return authToken.get().get();
   }
 
   @Override

--- a/src/test/java/dev/streamx/sling/connector/impl/StreamxClientConfigImplTest.java
+++ b/src/test/java/dev/streamx/sling/connector/impl/StreamxClientConfigImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.junit.jupiter.api.Test;
 
@@ -32,5 +33,14 @@ class StreamxClientConfigImplTest {
             List.of(resourcePathPatterns), streamxClientConfig.getResourcePathPatterns()
         )
     );
+  }
+
+  @Test
+  void mustFallbackForFailedInterpolation() {
+    SlingContext context = new SlingContext();
+    String authToken = "$[secret:STREAMX_CLIENT_AUTH_TOKEN]";
+    StreamxClientConfig streamxClientConfig = context.registerInjectActivateService(
+        StreamxClientConfigImpl.class, Map.of("authToken", authToken));
+    assertEquals(StringUtils.EMPTY, streamxClientConfig.getAuthToken());
   }
 }


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [ ] Non-breaking change
- [X] Bug fix / minor change

## 🛠 Changes being made

1. **Interpolation in AEMaaCS**  
   In Adobe Experience Manager as a Cloud Service (AEMaaCS), OSGi secrets are configured using an interpolation template (see [[AEMaaCS documentation](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi#secret-configuration-values)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi#secret-configuration-values)). For example, a typical secret interpolation template might look like:  
   ```
   $[secret:STREAMX_CLIENT_AUTH_TOKEN]
   ```

2. **Missing Property in Local Environments**  
   Proper interpolation requires a specific Apache Felix property to be set (see [[Felix ConfigAdmin interpolation plugin docs](https://github.com/apache/felix-dev/blob/e479f6517c4bcbf5fcdd73c20b8760fe1610ab3a/configadmin-plugins/interpolation/README.md?plain=1#L133)](https://github.com/apache/felix-dev/blob/e479f6517c4bcbf5fcdd73c20b8760fe1610ab3a/configadmin-plugins/interpolation/README.md?plain=1#L133)). This property is already configured in the real AEMaaCS environment but is not present by default in local versions. As a result, when running AEMaaCS locally, the interpolation step fails and instead returns the literal interpolation template (e.g., `$[secret:STREAMX_CLIENT_AUTH_TOKEN]`) rather than the actual secret.

3. **Impact of Failed Interpolation**  
   Because local clients receive the unresolved interpolation template instead of a real secret, they mistakenly treat it as a valid secret token (e.g., for authenticating to restricted services). This leads to access failures since the string `$[secret:STREAMX_CLIENT_AUTH_TOKEN]` is obviously not a usable token.

4. **Proposed Fix**  
   This PR addresses the issue by returning an empty string (`""`) if interpolation fails, rather than passing along the literal interpolation template. Returning an empty string prevents clients from inadvertently attempting to use the template as an actual secret and makes it clear that no valid secret is available.

## ✅ Checklist

- [X] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [ ] Changed code is covered with unit tests
- [X] I have updated READMEs and java docs (if applicable)
