### PR TITLE
DXP-1607: Add generic internal request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>dev.streamx</groupId>
@@ -189,6 +191,24 @@
       <version>4.2.12</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.engine</artifactId>
+      <version>2.16.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+      <version>2.27.6</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlet-helpers</artifactId>
+      <version>1.4.6</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- OSGi Metadata (not used in runtime)-->
     <dependency>
@@ -224,9 +244,27 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.18.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+      <version>2.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/dev/streamx/sling/connector/SimpleInternalRequest.java
+++ b/src/main/java/dev/streamx/sling/connector/SimpleInternalRequest.java
@@ -1,0 +1,136 @@
+package dev.streamx.sling.connector;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.uri.SlingUri;
+import org.apache.sling.engine.SlingRequestProcessor;
+import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
+import org.apache.sling.servlethelpers.internalrequests.InternalRequest;
+import org.apache.sling.servlethelpers.internalrequests.SlingInternalRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple internal HTTP request to a {@link SlingUri}.
+ */
+@SuppressWarnings("WeakerAccess")
+public class SimpleInternalRequest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleInternalRequest.class);
+
+  private final ResourceResolver resourceResolver;
+  private final SlingRequestProcessor slingRequestProcessor;
+  private final SlingUri slingUri;
+
+  /**
+   * Constructs a new instance of this class.
+   *
+   * @param slingUri              {@link SlingUri} to request
+   * @param slingRequestProcessor {@link SlingRequestProcessor} to use for request processing
+   * @param resourceResolver      {@link ResourceResolver} to use for accessing {@link Resource}s
+   */
+  public SimpleInternalRequest(
+      SlingUri slingUri,
+      SlingRequestProcessor slingRequestProcessor,
+      ResourceResolver resourceResolver
+  ) {
+    this.resourceResolver = resourceResolver;
+    this.slingUri = slingUri;
+    this.slingRequestProcessor = slingRequestProcessor;
+  }
+
+  /**
+   * Returns the content type of the HTTP response.
+   *
+   * @return content type of the HTTP response
+   */
+  public String contentType() {
+    try {
+      String contentType = internalRequest()
+          .execute()
+          .getResponse()
+          .getContentType();
+      LOG.trace("Content type for '{}' is '{}'", slingUri, contentType);
+      return contentType;
+    } catch (IOException exception) {
+      String message = String.format("Failed to determine content type for '%s'", slingUri);
+      LOG.error(message, exception);
+      return StringUtils.EMPTY;
+    }
+  }
+
+  /**
+   * Returns the {@link Optional} containing the body of the HTTP response.
+   *
+   * @return {@link Optional} containing the body of the HTTP response; empty {@link Optional} is
+   * returned if the response body cannot be retrieved
+   */
+  public Optional<InputStream> getResponseAsInputStream() {
+    try {
+      SlingHttpServletResponse response = internalRequest()
+          .execute()
+          .getResponse();
+      Optional<InputStream> inputStream = Optional.of(response)
+          .filter(MockSlingHttpServletResponse.class::isInstance)
+          .map(MockSlingHttpServletResponse.class::cast)
+          .map(MockSlingHttpServletResponse::getOutput)
+          .map(ByteArrayInputStream::new);
+      LOG.debug("Generated {} for '{}'", inputStream, slingUri);
+      return inputStream;
+    } catch (IOException exception) {
+      String message = String.format("Failed to generate response for '%s'", slingUri);
+      LOG.error(message, exception);
+      return Optional.empty();
+    }
+  }
+
+  private InternalRequest internalRequest() {
+    AbstractMap.SimpleEntry<String, String> wcmmode = new AbstractMap.SimpleEntry<>(
+        "wcmmode", "disabled"
+    );
+    Map<String, Object> pathParameters = Stream.concat(
+        slingUri.getPathParameters().entrySet().stream(), Stream.of(wcmmode)
+    ).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    String path = Optional.ofNullable(slingUri.getResourcePath()).orElse(StringUtils.EMPTY);
+    LOG.trace("Creating internal request for '{}'. Resolved path: {}", slingUri, path);
+    return new SlingInternalRequest(
+        resourceResolver, slingRequestProcessor, path
+    ).withExtension(slingUri.getExtension())
+        .withSelectors(slingUri.getSelectors())
+        .withParameters(pathParameters);
+  }
+
+  /**
+   * Returns the body of the HTTP response represented as {@link String}.
+   *
+   * @return body of the HTTP response represented as {@link String}; {@link StringUtils#EMPTY} is
+   * returned if the response body cannot be retrieved
+   */
+  public String getResponseAsString() {
+    try {
+      String responseAsString = internalRequest()
+          .execute()
+          .getResponseAsString();
+      LOG.debug(
+          "Generated response as string for '{}'. Response length: {}",
+          slingUri, responseAsString.length()
+      );
+      return responseAsString;
+    } catch (IOException exception) {
+      String message = String.format("Failed to generate response as string for '%s'", slingUri);
+      LOG.error(message, exception);
+      return StringUtils.EMPTY;
+    }
+  }
+}

--- a/src/main/java/dev/streamx/sling/connector/package-info.java
+++ b/src/main/java/dev/streamx/sling/connector/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.3.0")
+@Version("1.4.0")
 package dev.streamx.sling.connector;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/dev/streamx/sling/connector/SimpleInternalRequestTest.java
+++ b/src/test/java/dev/streamx/sling/connector/SimpleInternalRequestTest.java
@@ -1,0 +1,123 @@
+package dev.streamx.sling.connector;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.uri.SlingUri;
+import org.apache.sling.api.uri.SlingUriBuilder;
+import org.apache.sling.engine.SlingRequestProcessor;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SlingContextExtension.class)
+class SimpleInternalRequestTest {
+
+  private SlingContext context;
+  private SlingRequestProcessor slingRequestProcessor;
+
+  private static class BasicRequestProcessor implements SlingRequestProcessor {
+
+    @SuppressWarnings({"IfCanBeSwitch", "IfStatementWithTooManyBranches"})
+    @Override
+    public void processRequest(
+        HttpServletRequest request, HttpServletResponse response, ResourceResolver resourceResolver
+    ) throws IOException {
+      String requestURI = request.getRequestURI();
+      if (requestURI.equals("/content/mars-page.plain.html")) {
+        response.setContentType("text/html");
+        response.getWriter().write("<html><body><h1>Plain Mars Page</h1></body></html>");
+      } else if (requestURI.equals("/content/usual-mars-page.html")) {
+        response.setContentType("text/html");
+        response.getWriter().write("<html><body><h1>Usual Mars Page</h1></body></html>");
+      } else if (requestURI.equals("/content/binary-data.jpg")) {
+        @SuppressWarnings({"MagicNumber", "squid:S117"})
+        int dataSize = 1024;
+        response.setContentType("application/octet-stream");
+        response.setContentLength(dataSize);
+        byte[] randomData = new byte[dataSize];
+        new Random().nextBytes(randomData);
+        try (OutputStream out = response.getOutputStream()) {
+          out.write(randomData);
+          out.flush();
+        }
+      } else {
+        response.setContentType("text/html");
+        response.getWriter().write("<html><body><h1>Not Found</h1></body></html>");
+      }
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    context = new SlingContext();
+    slingRequestProcessor = context.registerService(
+        SlingRequestProcessor.class,
+        new BasicRequestProcessor()
+    );
+  }
+
+  @SuppressWarnings({"MagicNumber", "resource"})
+  @Test
+  void mustProduceString() {
+    ResourceResolver resourceResolver = context.resourceResolver();
+    SlingUri plainMarsUri = SlingUriBuilder.parse(
+        "/content/mars-page.plain.html", resourceResolver
+    ).build();
+    SlingUri usualMarsUri = SlingUriBuilder.parse(
+        "/content/usual-mars-page.html", resourceResolver
+    ).build();
+    SlingUri unknownPageUri = SlingUriBuilder.parse(
+        "/content/unknown-page.html", resourceResolver
+    ).build();
+    SlingUri binaryUri = SlingUriBuilder.parse(
+        "/content/binary-data.jpg", resourceResolver
+    ).build();
+    SimpleInternalRequest plainMarsRequest = new SimpleInternalRequest(
+        plainMarsUri, slingRequestProcessor, resourceResolver
+    );
+    SimpleInternalRequest usualMarsRequest = new SimpleInternalRequest(
+        usualMarsUri, slingRequestProcessor, resourceResolver
+    );
+    SimpleInternalRequest unknownRequest = new SimpleInternalRequest(
+        unknownPageUri, slingRequestProcessor, resourceResolver
+    );
+    SimpleInternalRequest binaryRequest = new SimpleInternalRequest(
+        binaryUri, slingRequestProcessor, resourceResolver
+    );
+
+    assertAll(
+        () -> assertEquals(
+            "<html><body><h1>Plain Mars Page</h1></body></html>",
+            plainMarsRequest.getResponseAsString()
+        ),
+        () -> assertEquals(
+            "<html><body><h1>Usual Mars Page</h1></body></html>",
+            usualMarsRequest.getResponseAsString()
+        ),
+        () -> assertEquals(
+            "<html><body><h1>Not Found</h1></body></html>",
+            unknownRequest.getResponseAsString()
+        ),
+        () -> assertEquals("text/html", plainMarsRequest.contentType()),
+        () -> assertEquals("text/html", usualMarsRequest.contentType()),
+        () -> assertEquals("text/html", unknownRequest.contentType()),
+        () -> assertEquals("application/octet-stream", binaryRequest.contentType()),
+        () -> assertEquals(
+            50, plainMarsRequest.getResponseAsInputStream().orElseThrow().readAllBytes().length
+        ),
+        () -> assertEquals(
+            1024, binaryRequest.getResponseAsInputStream().orElseThrow().readAllBytes().length
+        )
+    );
+  }
+
+}

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,2 +1,2 @@
-org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.log.dev.streamx.sling.connector=debug
+org.slf4j.simpleLogger.defaultLogLevel=OFF
+org.slf4j.simpleLogger.log.dev.streamx.sling.connector=OFF


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [X] Non-breaking change
- [ ] Bug fix / minor change

## 🛠 Changes being made

1. Some AEM pages reference embedded assets using proxy paths rather than direct DAM paths. For example, an image might be referenced at `/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.320.jpeg/1740144613537/mountain-range.jpeg` instead of `/content/dam/core-components-examples/library/sample-assets/mountain-range.jpg`), like this:

````html
<div data-cmp-is="image" data-cmp-widths="320,480,600,800,1024,1200,1600"
     data-cmp-src="/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85{.width}.jpeg/1740144613537/mountain-range.jpeg"
     data-cmp-filereference="/content/dam/core-components-examples/library/sample-assets/mountain-range.jpg"
     id="image-c6151cc37f"
     data-cmp-data-layer="{&#34;image-c6151cc37f&#34;:{&#34;@type&#34;:&#34;firsthops/components/image&#34;,&#34;repo:modifyDate&#34;:&#34;2025-02-21T13:30:13Z&#34;,&#34;dc:title&#34;:&#34;Aerial photo of mountain range&#34;,&#34;image&#34;:{&#34;repo:id&#34;:&#34;c0a39183-23f4-48f0-8db7-bb41ba2b0122&#34;,&#34;repo:modifyDate&#34;:&#34;2025-02-20T14:51:48Z&#34;,&#34;@type&#34;:&#34;image/jpeg&#34;,&#34;repo:path&#34;:&#34;/content/dam/core-components-examples/library/sample-assets/mountain-range.jpg&#34;}}}"
     data-cmp-hook-image="imageV3" class="cmp-image" itemscope
     itemtype="http://schema.org/ImageObject">

  <img
      src="/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.jpeg/1740144613537/mountain-range.jpeg"
      srcset="/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.320.jpeg/1740144613537/mountain-range.jpeg 320w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.480.jpeg/1740144613537/mountain-range.jpeg 480w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.600.jpeg/1740144613537/mountain-range.jpeg 600w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.800.jpeg/1740144613537/mountain-range.jpeg 800w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.1024.jpeg/1740144613537/mountain-range.jpeg 1024w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.1200.jpeg/1740144613537/mountain-range.jpeg 1200w,/content/firsthops/us/en/_jcr_content/root/container/container/image.coreimg.85.1600.jpeg/1740144613537/mountain-range.jpeg 1600w"
      loading="lazy" class="cmp-image__image" itemprop="contentUrl" width="850" height="509"
      alt="Aerial photo of mountain range" title="Aerial photo of mountain range"/>


  <meta itemprop="caption" content="Aerial photo of mountain range"/>
</div>
````

2. In order for StreamX to properly serve these assets at their proxied paths, the AEM/Sling StreamX Connector must publish the assets to those paths. Currently, such publishing does not occur, preventing StreamX from serving these assets through their proxy references. This should be changed so that such publishing and serving are performed.

3. This PR adds `SimpleInternalRequest` utility that will be used by AEM StreamX Connector to enable publishing and serving of assets at these proxied paths.

## ✅ Checklist

- [X] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [X] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
